### PR TITLE
Doc Robot icon scale fix

### DIFF
--- a/Gondola-pk3/TEXTURES.GIBUS
+++ b/Gondola-pk3/TEXTURES.GIBUS
@@ -387,7 +387,7 @@ graphic PLMWICON,30,30{XScale 2.0 YScale 2.0 Patch MEOWICON,0,0}//Nitro
 graphic JUNKRCON,30,30{XScale 2.0 YScale 2.0 Patch RSH1Y0,0,0}//Junk
 
 //DOC
-graphic DOC1Icon,30,30{Patch DOCICON1,0,0}
-graphic DOC2Icon,30,30{Patch DOCICON2,0,0}
-graphic DOC3Icon,30,30{Patch DOCICON3,0,0}
-graphic DOC4Icon,30,30{Patch DOCICON4,0,0}
+graphic DOC1Icon,30,30{XScale 2.0 YScale 2.0 Patch DOCICON1,0,0}
+graphic DOC2Icon,30,30{XScale 2.0 YScale 2.0 Patch DOCICON2,0,0} 
+graphic DOC3Icon,30,30{XScale 2.0 YScale 2.0 Patch DOCICON3,0,0}
+graphic DOC4Icon,30,30{XScale 2.0 YScale 2.0 Patch DOCICON4,0,0}

--- a/Gondola-pk3/actors/Wep/Megaman3/DocWeapon.txt
+++ b/Gondola-pk3/actors/Wep/Megaman3/DocWeapon.txt
@@ -7,7 +7,7 @@ Weapon.AmmoGive 3
 Weapon.SlotNumber 1
 Obituary "$OB_DOCBUSTER"
 weapon.ammotype "DocVirusAmmo"
-inventory.icon "DocIcon1"
+inventory.icon "DOC1Icon"
 States
 {
 Spawn:
@@ -77,7 +77,7 @@ Weapon.AmmoGive 3
 Weapon.SlotNumber 1
 Obituary "$OB_DOCBUSTER"
 weapon.ammotype "DocVirusAmmo"
-inventory.icon "DocIcon2"
+inventory.icon "DOC2Icon"
 States
 {
 Spawn:
@@ -147,7 +147,7 @@ Weapon.AmmoGive 3
 Weapon.SlotNumber 1
 Obituary "$OB_DOCBUSTER"
 weapon.ammotype "DocVirusAmmo"
-inventory.icon "DocIcon3"
+inventory.icon "DOC3Icon"
 States
 {
 Spawn:
@@ -217,7 +217,7 @@ Weapon.AmmoGive 3
 Weapon.SlotNumber 1
 Obituary "$OB_DOCBUSTER"
 weapon.ammotype "DocVirusAmmo"
-inventory.icon "DocIcon4"
+inventory.icon "DOC4Icon"
 States
 {
 Spawn:


### PR DESCRIPTION
Gibus, in his infinite wisdom, gives Doc Robot a graphic definition to turn his icon sprites into correctly sized icon graphics, then uses the *sprite* names rather than the *graphic* names in Decorate.

And he forgot the scale!