### PR TITLE
Correcting the Runes of Kauf-Kaul

### DIFF
--- a/Gondola-pk3/actors/Megaman3/GeminiLaserboss.txt
+++ b/Gondola-pk3/actors/Megaman3/GeminiLaserboss.txt
@@ -3,7 +3,7 @@ actor GeminiLaserBoss : BaseMM8BDMWep_CBM
 Tag "$TAGC_3C"
 dropitem "GeminiLaserWepCDropped"
 Weapon.AmmoUse 0
-Weapon.AmmoGive 28
+Weapon.AmmoGive 100
 Obituary "$OB_GEMINILASER"
 weapon.ammotype "SeeingDoubleAmmo"
 States
@@ -17,10 +17,10 @@ GEMB A 0 ACS_ExecuteAlways(998,0,DYE_GEMINIMAN)
 Ready1:
 GEMB A 0 A_JumpIfInventory("CloneSpawned",1,"FullReady")
 GEMB A 0 A_JumpIfInventory("CloneSpawning",1,"FullReady")
-GEMB A 0 A_JumpIfInventory("SeeingDoubleAmmo",28,"FullReady")
+GEMB A 0 A_JumpIfInventory("SeeingDoubleAmmo",100,"FullReady")
 GEMB A 7 A_WeaponReady
 GEMB A 0 A_JumpIfInventory("CloneSpawned",1,"FullReady")
-GEMB A 0 A_GiveInventory("SeeingDoubleAmmo",1)
+GEMB A 0 A_GiveInventory("SeeingDoubleAmmo",4)
 Goto Ready1+1
 FullReady:
 GEMB A 1 A_WeaponReady
@@ -43,7 +43,7 @@ GEMB BC 2
 GEMB CCBA 1
 GEMB A 8
 GEMB A 0 A_JumpIfInventory("CloneSpawned",1,2)
-GEMB A 0 A_GiveInventory("SeeingDoubleAmmo",1)
+GEMB A 0 A_GiveInventory("SeeingDoubleAmmo",4)
 GEMB A 0 A_ReFire
 Goto Ready1+1
 
@@ -52,7 +52,7 @@ GEMB A 0 A_Jump(8,2)
 GEMB A 0 A_Jump(96,"GeminiLaser")
 goto Fire+1
 GEMB A 0 A_JumpIfInventory("CloneSpawned",1,4)
-GEMB A 1 A_GiveInventory("SeeingDoubleAmmo",28)
+GEMB A 1 A_GiveInventory("SeeingDoubleAmmo",100)
 GEMB A 2 A_GiveInventory("GemSpawnerAuto",1)
 GEMB A 12 A_TakeInventory("GemSpawnerAuto",1)
 goto AltFire
@@ -64,7 +64,7 @@ AltFire:
 //TNT1 A 0 A_JumpIfInventory("GeminiItemSet",1,"NoAmmo")
 //TNT1 A 0 A_JumpIfInventory("GeminiItemUnSet",1,"NoAmmo")
 GEMB A 0 A_JumpIfInventory("CloneSpawned",1,"Set")
-GEMM A 0 A_JumpIfInventory("SeeingDoubleAmmo",4,"GeminiLaser")
+GEMM A 0 A_JumpIfInventory("SeeingDoubleAmmo",14,"GeminiLaser")
 goto NoAmmo
 GeminiLaser:
 GEMB A 0 A_TakeInventory("SpawningMisfire",1)
@@ -97,7 +97,7 @@ GEMB A 0 A_TakeInventory("SpawningMisfire",1)
 Goto Ready1+1
 NoAmmo:
 GEMB A 8
-GEMB A 0 A_GiveInventory("SeeingDoubleAmmo",1)
+GEMB A 0 A_GiveInventory("SeeingDoubleAmmo",4)
 Goto Ready1+1
 
 Flash:
@@ -443,7 +443,7 @@ FireP:
 TNT1 A 0 A_FireCustomMissile("BossGeminiLaserP",0,1,8,0)
 goto Done
 Done:
-TNT1 A 0 A_TakeInventory("SeeingDoubleAmmo",4)
+TNT1 A 0 A_TakeInventory("SeeingDoubleAmmo",14)
 stop
 }
 }
@@ -464,7 +464,7 @@ loop
 Use:
 TNT1 A 0 A_JumpIfInventory("CloneSpawning",1,"BugFix")
 TNT1 A 0 A_JumpIfInventory("CloneSpawned",1,"Success2")
-TNT1 A 0 A_JumpIfInventory("SeeingDoubleAmmo",28,"Success")
+TNT1 A 0 A_JumpIfInventory("SeeingDoubleAmmo",100,"Success")
 fail
 Success:
 //TNT1 A 0 A_SpawnItemEx("GemClone",0,0,28,0,0,0,0,0)//SXF_SETMASTER
@@ -505,7 +505,7 @@ TNT1 A 0 A_PlaySoundEx("S3_K/MetalSpark","Voice")
 fail
 BugPatch:
 TNT1 A 0
-TNT1 A 0 A_TakeInventory("SeeingDoubleAmmo",14)
+TNT1 A 0 A_TakeInventory("SeeingDoubleAmmo",50)
 TNT1 A 0 A_TakeInventory("CloneSpawning",999)
 TNT1 A 0 A_TakeInventory("CloneAngle",999)
 TNT1 A 0 A_TakeInventory("CloneDistance",999)
@@ -1165,7 +1165,7 @@ actor SeeingDoubleAmmo : Ammo
 {
 +INVENTORY.IGNORESKILL 
 inventory.amount 1
-inventory.maxamount 28
+inventory.maxamount 100
 }
 
 actor CloneSpawning : Inventory

--- a/Gondola-pk3/actors/Megaman5/DarkFourBusterBoss.txt
+++ b/Gondola-pk3/actors/Megaman5/DarkFourBusterBoss.txt
@@ -500,7 +500,7 @@ Alpha 0.35
 Translation "192:192=85:85", "198:198=227:227"
 Height 56
 Radius 30
-health 50
+health 500
 States
 {
 Spawn:

--- a/Gondola-pk3/actors/MegamanK/MirrorBusterBoss.txt
+++ b/Gondola-pk3/actors/MegamanK/MirrorBusterBoss.txt
@@ -86,9 +86,9 @@
 
 		Fire_AltReset:
 		ENKA A 0 A_TakeInventory("EnkerAbsorbCount",1)
-		ENKA A 0 A_TakeInventory("StunArmor",99)
-		ENKA A 0 A_TakeInventory("BasicArmor",999)
-		ENKA A 0 A_TakeInventory("LastArmorCount",999)
+		ENKA A 0 A_TakeInventory("StunArmor",990)
+		ENKA A 0 A_TakeInventory("BasicArmor",9990)
+		ENKA A 0 A_TakeInventory("LastArmorCount",9990)
 		ENKA A 0 SetPlayerProperty(0,0,0)
 		ENKA A 0 ACS_ExecuteAlways(CORE_ACS_191,0,APROP_JumpZ,10,1)
 		ENKA A 0 A_GiveInventory("EnkerAltCooldown_RC",1)
@@ -119,8 +119,9 @@
 		AltFire:
 		ENKA A 0 A_GiveInventory("EnkerAbsorbCount",1)
 		ENKA A 0 A_GiveInventory("EnkerArmor",1)
+		ENKA A 0 A_GiveInventory("SetDynamicArmorDosage_P",1)
 		ENKA A 0 A_GiveInventory("StunArmor",1)
-		ENKA A 0 A_GiveInventory("LastArmorCount",100)
+		ENKA A 0 A_GiveInventory("LastArmorCount",1000)
 		ENKA A 0 SetPlayerProperty(0,1,0)
 		ENKA A 0 ACS_ExecuteAlways(CORE_ACS_191,0,APROP_JumpZ,0,1)
 		ENKA A 0 A_PlaySoundEx("weapon/mirrorabsorb","Weapon")
@@ -196,6 +197,7 @@
 		AltfireEnd:
 		ENKA A 0 A_TakeInventory("EnkerAbsorbCount",1)
 		ENKA A 0 A_TakeInventory("EnkerAltCombo_F",99)
+		ENKA A 0 A_TakeInventory("DynamicArmorDosage_F")
 		ENKA A 0// A_TakeInventory("StunArmor",99)
 		ENKA A 0// A_TakeInventory("BasicArmor",999)
 		ENKA A 0// A_TakeInventory("LastArmorCount",999)
@@ -226,7 +228,7 @@
 		AltFireBot:
 		ENKA A 0 A_GiveInventory("EnkerAbsorbCount",1)
 		ENKA A 0 A_GiveInventory("EnkerArmor",1)
-		ENKA A 0 A_GiveInventory("LastArmorCount",100)
+		ENKA A 0 A_GiveInventory("LastArmorCount",1000)
 		ENKA A 0 SetPlayerProperty(0,1,0)
 		ENKA A 0 ACS_ExecuteAlways(CORE_ACS_191,0,APROP_JumpZ,0,1)
 		ENKA A 0
@@ -235,8 +237,8 @@
 		ENKA E 29
 		ENKA DC 3
 		ENKA A 0 A_TakeInventory("EnkerAbsorbCount",1)
-		ENKA A 0 A_TakeInventory("BasicArmor",999)
-		ENKA A 0 A_TakeInventory("LastArmorCount",999)
+		ENKA A 0 A_TakeInventory("BasicArmor",9990)
+		ENKA A 0 A_TakeInventory("LastArmorCount",9990)
 		ENKA A 0 SetPlayerProperty(0,0,0)
 		ENKA A 0 ACS_ExecuteAlways(CORE_ACS_191,0,APROP_JumpZ,10,1)
 		Goto Fire+1
@@ -318,10 +320,10 @@ fail
 		Spawn:
 		TNT1 A 1 A_Countdown
 		Looping:
-		TNT1 A 0 A_TakeFromTarget("StunArmor",8)
-		TNT1 A 0 A_TakeFromTarget("BasicArmor",8)
-		TNT1 A 0 A_TakeFromTarget("BossBasicArmorAmount",8)
-		TNT1 A 0 A_TakeFromTarget("LastArmorCount",8)
+		TNT1 A 0 A_TakeFromTarget("StunArmor",80)
+		TNT1 A 0 A_TakeFromTarget("BasicArmor",80)
+		TNT1 A 0 A_TakeFromTarget("BossBasicArmorAmount",80)
+		TNT1 A 0 A_TakeFromTarget("LastArmorCount",80)
 		TNT1 A 1 A_Countdown
 		goto Looping
 		
@@ -339,9 +341,9 @@ fail
 		Spawn:
 		TNT1 A 1 A_Countdown
 		Looping:
-		TNT1 A 0 A_TakeFromTarget("StunArmor",16)
-		TNT1 A 0 A_TakeFromTarget("BasicArmor",16)
-		TNT1 A 0 A_TakeFromTarget("LastArmorCount",16)
+		TNT1 A 0 A_TakeFromTarget("StunArmor",160)
+		TNT1 A 0 A_TakeFromTarget("BasicArmor",160)
+		TNT1 A 0 A_TakeFromTarget("LastArmorCount",160)
 		TNT1 A 1 A_Countdown
 		goto Looping
 		
@@ -367,7 +369,7 @@ fail
   Actor EnkerArmor : BasicArmorPickup
   {
     Armor.Savepercent 95.005
-	Armor.Saveamount 100
+	Armor.Saveamount 1000
   }
 
 
@@ -387,7 +389,7 @@ fail
   Actor LastArmorCount : Inventory
   {
     Inventory.Amount 1
-	Inventory.MaxAmount 100
+	Inventory.MaxAmount 1000
   }
 
 


### PR DESCRIPTION
- Geminiman ammo cap 28 -> 100. Costs and regen scaled to compensate; empty to max ammo regen time 5.6sec -> 5sec. Fixes visual bug that causes clone health to not properly display.
- Dark4 shield health 50 -> 500. This should've happened in 10x.
- Enker armor 100 -> 1000. This should've happened in 10x. Related values for Decorate and ACS calculations 10xed in relation.