### PR TITLE
Galaxy/DrLight grief fixes

### DIFF
--- a/Gondola-pk3/acs_source/BUGFIX.acs
+++ b/Gondola-pk3/acs_source/BUGFIX.acs
@@ -100,7 +100,7 @@ script CBM_HealMyThing (int Which, int HPBoost)
 
 script "CBM_MainOpen" OPEN
 {
-	//IsTeamGame = ACS_ExecuteWithResult(975,1);
+	//IsTeamGame = ACS_ExecuteWithResult(975,1); //Whoever did this: for what reason?
 	//ServerMAX = GetMaxPlayers();
 }
 
@@ -719,7 +719,7 @@ script "cbm_missileyank" (int maxRange)
 		{
 			continue;
 		}
-		if(IsTeamGame)
+		if(ACS_ExecuteWithResult(975,1))
 		{
 			if(userTeam == GetPlayerInfo(p, PLAYERINFO_TEAM))
 			{
@@ -750,7 +750,7 @@ script "cbm_GalaxyBHB_ACS" (int maxforce, int maxforceZ, int maxRange)
 		if(!PlayerInGame(p)){
 			continue;
 		}
-		if(isTeamGame){
+		if(ACS_ExecuteWithResult(975,1)){
 			if(userTeam == GetPlayerInfo(p,PLAYERINFO_TEAM)){
 				continue;
 			}
@@ -848,7 +848,7 @@ script "cbm_GalaxyBHB_ACSEnd" (int maxRange)
 		if(!PlayerInGame(p)){
 			continue;
 		}
-		if(isTeamGame){
+		if(ACS_ExecuteWithResult(975,1)){
 			if(userTeam == GetPlayerInfo(p,PLAYERINFO_TEAM)){
 				continue;
 			}

--- a/Gondola-pk3/actors/Wep/copywepvisibility.txt
+++ b/Gondola-pk3/actors/Wep/copywepvisibility.txt
@@ -166,6 +166,7 @@ loop
 //0 - Iconless/Busters. Some of these are getting icons eventually, but that can wait.
 actor CWV_None:CWV_Template_Blank{} //Maestro is weird.
 actor CWV_MegaBusterC:CWV_Template_Blank{}
+actor CWV_MegaBusterBoss:CWV_Template_Blank{} //Fuck.
 actor CWV_JetBusterC:CWV_Template_Blank{} //Has wings.
 actor CWV_PowerFistC:CWV_Template_Blank{} //Has pads.
 actor CWV_HeroicProtoBuster:CWV_Template_Blank{}


### PR DESCRIPTION
removed seemingly erroneous instances of isTeamGame that allowed Dr. Light's Shinku Hadouken and Galaxyman's Black Hole Bomb to pull teammates. fixed megaman printing an error to the console due to a weapon name change.